### PR TITLE
doc: Update _guides/async-data.md

### DIFF
--- a/_guides/async-data.md
+++ b/_guides/async-data.md
@@ -54,8 +54,8 @@ const dataMiddleware = (routes) => (toState) => {
     const { toActivate } = transitionPath(toState, fromState);
     const onActivateHandlers =
         toActivate
-            .map(segment => routes.find(r => r.name === segment.name))
-            .filter(() => segment.onActivate !== undefined)
+            .map(segment => routes.find(r => r.name === segment))
+            .filter(segment => segment.onActivate !== undefined)
             .map(segment => segment.onActivate);
 
     return Promise


### PR DESCRIPTION
Pass `segment` through every stage of the operation. The middleware described in th previous version of this doc page threw an error, and I corrected it. This middleware now works as expected.
